### PR TITLE
Fixed nullSafe usage.

### DIFF
--- a/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
+++ b/gson/src/main/java/com/google/gson/internal/bind/JsonAdapterAnnotationTypeAdapterFactory.java
@@ -55,6 +55,7 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
     Object instance = constructorConstructor.get(TypeToken.get(annotation.value())).construct();
 
     TypeAdapter<?> typeAdapter;
+    boolean nullSafe = annotation.nullSafe();
     if (instance instanceof TypeAdapter) {
       typeAdapter = (TypeAdapter<?>) instance;
     } else if (instance instanceof TypeAdapterFactory) {
@@ -66,7 +67,8 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
       JsonDeserializer<?> deserializer = instance instanceof JsonDeserializer
           ? (JsonDeserializer) instance
           : null;
-      typeAdapter = new TreeTypeAdapter(serializer, deserializer, gson, type, null);
+      typeAdapter = new TreeTypeAdapter(serializer, deserializer, gson, type, null, nullSafe);
+      nullSafe = false;
     } else {
       throw new IllegalArgumentException("Invalid attempt to bind an instance of "
           + instance.getClass().getName() + " as a @JsonAdapter for " + type.toString()
@@ -74,7 +76,7 @@ public final class JsonAdapterAnnotationTypeAdapterFactory implements TypeAdapte
           + " JsonSerializer or JsonDeserializer.");
     }
 
-    if (typeAdapter != null && annotation.nullSafe()) {
+    if (typeAdapter != null && nullSafe) {
       typeAdapter = typeAdapter.nullSafe();
     }
 

--- a/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
+++ b/gson/src/test/java/com/google/gson/functional/JsonAdapterSerializerDeserializerTest.java
@@ -161,4 +161,22 @@ public final class JsonAdapterSerializerDeserializerTest extends TestCase {
       return new JsonPrimitive("BaseIntegerAdapter");
     }
   }
+
+  public void testJsonAdapterNullSafe() {
+    Gson gson = new Gson();
+    String json = gson.toJson(new Computer3(null, null));
+    assertEquals("{\"user1\":\"UserSerializerDeserializer\"}", json);
+    Computer3 computer3 = gson.fromJson("{\"user1\":null, \"user2\":null}", Computer3.class);
+    assertEquals("UserSerializerDeserializer", computer3.user1.name);
+    assertNull(computer3.user2);
+  }
+
+  private static final class Computer3 {
+    @JsonAdapter(value = UserSerializerDeserializer.class, nullSafe = false) final User user1;
+    @JsonAdapter(value = UserSerializerDeserializer.class) final User user2;
+    Computer3(User user1, User user2) {
+      this.user1 = user1;
+      this.user2 = user2;
+    }
+  }
 }


### PR DESCRIPTION
The JsonSerializer/Deserializer adapters used to ignore this attribute
which result in inconsistent behaviour for annotated adapters.

Signed-off-by: Dmitry Bufistov <dmitry@midokura.com>